### PR TITLE
[TRL-36] [Feat] 혜택 UI 구현, HeaderHome 컴포넌트 공용화

### DIFF
--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,0 +1,14 @@
+import HeaderHome from "@/components/common/HeaderHome";
+
+export default function EventsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <HeaderHome title="혜택" description="다양한 혜택을 확인하세요" />
+      {children}
+    </div>
+  );
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 export default function BenefitsPage() {
   return (
     <div className="pt-[155px] pb-8 flex justify-center">
-      <div className="w-[335px] min-h-[584px] rounded-[10px] shadow-card py-[12px] ">
+      <div className="w-[335px] min-h-[584px] rounded-[10px] shadow-card py-[12px] bg-white">
         <BenefitCategory categoryItem="멤버십">
           <div className="ml-[29px] mr-[18px] grid grid-cols-2 gap-y-2 gap-x-6">
             {MEMBERSHIP_ITEMS.map((item) => (

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,4 +1,11 @@
-import Header from "@/components/common/Header";
+import BenefitCategory from "@/components/events/BenefitCategory";
+import {
+  BILLING_BENEFIT_ITEMS,
+  EVENTS_ITEMS,
+  MEMBERSHIP_ITEMS,
+  PURCHASE_BENEFIT_ITEMS,
+  SPECIAL_BENEFIT_ITEMS,
+} from "@/utils/categoryType";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -7,12 +14,74 @@ export const metadata: Metadata = {
 
 export default function BenefitsPage() {
   return (
-    <div className="p-6">
-      <Header back text="혜택" />
-      <div className="space-y-4">
-        <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
-          <p className="text-text-lightgray">설정 페이지입니다.</p>
-        </div>
+    <div className="pt-[155px] pb-8 flex justify-center">
+      <div className="w-[335px] min-h-[584px] rounded-[10px] shadow-card py-[12px] ">
+        <BenefitCategory categoryItem="멤버십">
+          <div className="ml-[29px] mr-[18px] grid grid-cols-2 gap-y-2 gap-x-6">
+            {MEMBERSHIP_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm text-text-lightgray"
+              >
+                - {item.label}
+              </a>
+            ))}
+          </div>
+        </BenefitCategory>
+        <BenefitCategory categoryItem="이벤트">
+          <div className="ml-[29px] mr-[18px] grid grid-cols-2 gap-y-2 gap-x-6">
+            {EVENTS_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm text-text-lightgray"
+              >
+                - {item.label}
+              </a>
+            ))}
+          </div>
+        </BenefitCategory>
+        <BenefitCategory categoryItem="구매 혜택">
+          {/* 텍스트 길어서 grid 간격 일부 조정 */}
+          <div className="ml-[29px] mr-[30px] grid grid-cols-[1.2fr_1fr] gap-y-2 gap-x-4">
+            {PURCHASE_BENEFIT_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm text-text-lightgray"
+              >
+                - {item.label}
+              </a>
+            ))}
+          </div>
+        </BenefitCategory>
+        <BenefitCategory categoryItem="요금 혜택">
+          <div className="ml-[29px] mr-[18px] grid grid-cols-2 gap-y-2 gap-x-6">
+            {BILLING_BENEFIT_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm text-text-lightgray"
+              >
+                - {item.label}
+              </a>
+            ))}
+          </div>
+        </BenefitCategory>
+        <BenefitCategory categoryItem="스페셜 혜택">
+          <div className="ml-[29px] mr-[18px] grid grid-cols-2 gap-y-2 gap-x-6">
+            {SPECIAL_BENEFIT_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm text-text-lightgray"
+              >
+                - {item.label}
+              </a>
+            ))}
+          </div>
+        </BenefitCategory>
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,7 @@
 
   --color-text-lightgray: #717374;
   --color-text-darkgray: #333333;
+  --color-text-muted: #bbbbbb;
   --color-text-inverse: #f5f1eb;
 
   --font-suite-medium: "SUITE-Medium", sans-serif;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,12 +102,11 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #f5f1eb;
+    --foreground: #171717;
   }
 }
 
 body {
-  background: var(--background);
   color: var(--foreground);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="font-sans antialiased">
+      <body className="font-sans antialiased bg-text-inverse">
         <main className="min-h-screen pb-20">{children}</main>
         <TabBar />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <div className="pt-[139px] w-[393px] mx-auto">
-      <HeaderHome />
+      <HeaderHome title="SO:U+" description="안녕하세요, 김소유님" isHome />
       <SummaryStartCard />
       <ContentSection />
       <HelperSection />

--- a/src/components/common/HeaderHome.tsx
+++ b/src/components/common/HeaderHome.tsx
@@ -1,12 +1,28 @@
 import Image from "next/image";
 import LogoMini from "@/assets/images/logo_mini.svg";
 
-export default function HeaderHome() {
+interface HeaderHomeProps {
+  title: string;
+  description: string;
+  isHome?: boolean;
+}
+
+export default function HeaderHome({
+  title,
+  description,
+  isHome = false,
+}: HeaderHomeProps) {
   return (
-    <header className="fixed top-0 left-1/2 -translate-x-1/2 w-[393px] pt-[65px] bg-primary-500">
-      <div className="h-[90px] flex flex-col px-4 pl-6 text-white">
+    <header
+      className={`fixed top-0 left-1/2 -translate-x-1/2 w-[393px] pt-[65px] z-10 ${isHome ? "bg-primary-500" : "bg-text-inverse"}`}
+    >
+      <div
+        className={`h-[90px] flex flex-col px-4 pl-6 ${isHome ? "text-white" : "text-text-darkgray"}`}
+      >
         <div className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-xl bg-white/20 flex items-center justify-center">
+          <div
+            className={`w-8 h-8 rounded-xl flex items-center justify-center ${isHome ? "bg-white/20" : "bg-primary-200"}`}
+          >
             <Image
               src={LogoMini}
               alt="SO:U+ logo"
@@ -16,10 +32,12 @@ export default function HeaderHome() {
             />
           </div>
 
-          <p className="text-[25px] font-extrabold leading-none">SO:U+</p>
+          <p className="text-[25px] font-extrabold leading-none">{title}</p>
         </div>
 
-        <p className="mt-2 font-medium">안녕하세요, 김소유님</p>
+        <p className={`mt-2 font-medium ${!isHome && "text-text-lightgray"}`}>
+          {description}
+        </p>
       </div>
     </header>
   );

--- a/src/components/common/HeaderHome.tsx
+++ b/src/components/common/HeaderHome.tsx
@@ -35,7 +35,9 @@ export default function HeaderHome({
           <p className="text-[25px] font-extrabold leading-none">{title}</p>
         </div>
 
-        <p className={`mt-2 font-medium ${!isHome && "text-text-lightgray"}`}>
+        <p
+          className={`mt-2 font-medium ${!isHome ? "text-text-lightgray" : ""}`}
+        >
           {description}
         </p>
       </div>

--- a/src/components/events/BenefitCategory.tsx
+++ b/src/components/events/BenefitCategory.tsx
@@ -12,7 +12,7 @@ export default function BenefitCategory({
   categoryItem,
   children,
 }: BenefitCategoryProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   return (
     <>

--- a/src/components/events/BenefitCategory.tsx
+++ b/src/components/events/BenefitCategory.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+interface BenefitCategoryProps {
+  categoryItem: string;
+  children?: React.ReactNode;
+}
+
+export default function BenefitCategory({
+  categoryItem,
+  children,
+}: BenefitCategoryProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        className="mx-[21px] h-[48px] w-[293px] flex items-center justify-between"
+      >
+        <p className="text-lg font-bold">{categoryItem}</p>
+
+        <ChevronDown
+          className={`stroke-text-darkgray transition-transform duration-200
+          ${isOpen ? "rotate-180" : "rotate-0"}`}
+        />
+      </button>
+      {isOpen && (
+        <div className="mx-5 border-b border-text-muted origin-bottom scale-y-75"></div>
+      )}
+      {isOpen && (
+        <div className="mt-2 mb-3 transition-all duration-200 ease-out">
+          {children}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/utils/categoryType.ts
+++ b/src/utils/categoryType.ts
@@ -1,0 +1,105 @@
+export const MEMBERSHIP_ITEMS = [
+  {
+    label: "나의 멤버십",
+    href: "https://www.lguplus.com/benefit-membership/rank-info",
+  },
+  {
+    label: "멤버십 제휴사",
+    href: "https://www.lguplus.com/benefit-membership",
+  },
+  { label: "유플투쁠", href: "https://www.lguplus.com/benefit-plus" },
+  {
+    label: "멤버십 이용 내역",
+    href: "https://account.lguplus.com/login?client_id=G8RoYUvnwILirwwwK3xG4WR8q9D83to7&login_type=STANDARD_WEB&prompt=select_account&i18nextLng=ko",
+  },
+  {
+    label: "영화예매",
+    href: "https://www.lguplus.com/benefit-membership/movie-booking/guest",
+  },
+];
+
+export const EVENTS_ITEMS = [
+  {
+    label: "출석체크",
+    href: "https://www.lguplus.com/benefit-event/ongoing/82129",
+  },
+  {
+    label: "선호번호 신청 이벤트",
+    href: "https://www.lguplus.com/benefit-event/preferred-number",
+  },
+  {
+    label: "진행 중 이벤트",
+    href: "https://www.lguplus.com/benefit-event/ongoing",
+  },
+  {
+    label: "당첨자 발표",
+    href: "https://www.lguplus.com/benefit-event/winner",
+  },
+  { label: "지난 이벤트", href: "https://www.lguplus.com/benefit-event/past" },
+];
+
+export const PURCHASE_BENEFIT_ITEMS = [
+  {
+    label: "쇼핑쿠폰팩/너겟쿠폰",
+    href: "https://account.lguplus.com/login?client_id=G8RoYUvnwILirwwwK3xG4WR8q9D83to7&login_type=STANDARD_WEB&prompt=select_account&i18nextLng=ko",
+  },
+  {
+    label: "제휴카드 할인",
+    href: "https://www.lguplus.com/benefit-affiliate/card-discount",
+  },
+  {
+    label: "온라인스토어 전용 혜택",
+    href: "https://www.lguplus.com/benefit-uplus/member-private-benefit",
+  },
+  {
+    label: "포인트파크 할인",
+    href: "https://www.lguplus.com/benefit-affiliate/point-discount/PDT0030748",
+  },
+  {
+    label: "온라인스토어 구매 혜택",
+    href: "https://www.lguplus.com/benefit-uplus/online-purchase-benefit/ORN0030802",
+  },
+  {
+    label: "중고폰 가격 보장",
+    href: "https://www.lguplus.com/benefit-uplus/used-phone-compensation",
+  },
+];
+
+export const BILLING_BENEFIT_ITEMS = [
+  {
+    label: "모바일 요금 할인",
+    href: "https://www.lguplus.com/benefit-uplus/price-discount",
+  },
+  {
+    label: "결합 할인",
+    href: "https://www.lguplus.com/benefit-uplus/combined-discount",
+  },
+  {
+    label: "선택 약정 할인",
+    href: "https://www.lguplus.com/benefit-uplus/price-discount/B400000003",
+  },
+];
+export const SPECIAL_BENEFIT_ITEMS = [
+  {
+    label: "장기고객 혜택",
+    href: "https://www.lguplus.com/benefit-uplus/loyal-member-perks/longBene",
+  },
+  { label: "갤럭시 패밀리폰", href: "https://www.lguplus.com/family-phone" },
+  { label: "유쓰 혜택", href: "https://www.lguplus.com/uth" },
+  {
+    label: "소노 라이프케어",
+    href: "https://www.lguplus.com/benefit-affiliate/affiliate/JCB0030748",
+  },
+  {
+    label: "ez포인트",
+    href: "https://www.lguplus.com/benefit-uplus/used-phone-compensation/signup/Oldphone",
+  },
+  {
+    label: "중고폰 보상 신청",
+    href: "https://www.lguplus.com/benefit-uplus/used-phone-compensation/signup/Oldphone",
+  },
+  {
+    label: "U+tv 프리미엄 클럽",
+    href: "https://www.lguplus.com/premiumclub-pack",
+  },
+];


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- HeaderHome 컴포넌트 재사용을 위해 공용화했습니다.
- 혜택 UI 구현 및 각 카테고리 별 하위항목에 url을 연결했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- HeaderHome.tsx
- /app/page.tsx
- /app/layout.tsx
- globals.css

`/events` 관련
- layout.tsx
- page.tsx
- categoryType.ts
- BenefitCategory.tsx

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
- 각 도메인 별 page에 헤더 컴포넌트 호출을 제외하려고 각 도메인마다 `layout.tsx`를 생성해서 해당 파일에 헤더 컴포넌트를 호출하는 방식을 선택했습니다.


## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

https://github.com/user-attachments/assets/31af124c-6b65-4cde-9b2f-0a6b09db7f43



## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- `events/page.tsx`에서 `PURCHASE_BENEFIT_ITEMS` 부분은 `grid-cols-[1.2fr_1fr]`로 되어있는데, 이는 하위 아이템의 글자수가 길어서 아래로 내려감을 방지하고자 해당 부분의 css만 살짝 다르게 설정하였습니다. 감안하고 확인해주시면 감사하겠습니다!
   - `grid-cols-[1.2fr_1fr]` : 2열 그리드에서 남은 가로 공간을 비율로 나눠, 왼쪽 열에 오른쪽보다 약 20% 더 많은 너비를 주는 설정


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`/events/layout.tsx`
- 다른 도메인에서 작업할 때 layout.tsx도 함께 작성해주시면 감사하겠습니다.
```swift
import HeaderHome from "@/components/common/HeaderHome";

export default function EventsLayout({
  children,
}: {
  children: React.ReactNode;
}) {
  return (
    <div>
      <HeaderHome title="혜택" description="다양한 혜택을 확인하세요" />
       // HeaderHome 컴포넌트 재사용
      {children}
    </div>
  );
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 이벤트 페이지에 멤버십·이벤트·구매·요금·스페셜 등 카테고리별 혜택 섹션 추가
  * 확장/축소 가능한 카테고리(토글형) 인터랙션 추가
  * 이벤트 섹션 전용 레이아웃 적용으로 콘텐츠 구조화

* **스타일**
  * 헤더에 커스텀 제목·설명·홈 플래그 적용 가능
  * 앱 테마 색상 및 헤더 디자인(다크/라이트 색상 조정) 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->