### PR TITLE
[TRL-76] [Feat] 상태관리 & Cache Control

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,4 +1,3 @@
-// src/app/providers.tsx
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -8,6 +7,12 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 10,
+      gcTime: 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      retry: 1,
+    },
+    mutations: {
       retry: 1,
     },
   },

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from "react";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 10, // 10분 동안 fresh
+      staleTime: 1000 * 60 * 10,
       retry: 1,
     },
   },

--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -11,7 +11,7 @@ export default function HomeContent() {
   const { nickname, isLoading } = useUserProfile();
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center mb-8">
       <HeaderHome 
         title="SO:U+" 
         description={isLoading ? "안녕하세요" : `안녕하세요, ${nickname}님`}

--- a/src/components/settings/SettingContents.tsx
+++ b/src/components/settings/SettingContents.tsx
@@ -14,7 +14,6 @@ export default function SettingsContent() {
   const { nickname, isLoading } = useUserProfile();
 
   return (
-    <>
       <div className="flex flex-col items-center">
         <div className="w-[80px] h-[80px] rounded-2xl bg-secondary-800 flex items-center justify-center mb-[9px]">
           <User className="w-[50px] h-[50px] stroke-white" />
@@ -49,6 +48,5 @@ export default function SettingsContent() {
 
         <AccountActions />
       </div>
-    </>
   );
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -8,15 +8,14 @@ export function useUserProfile() {
   const { data, isLoading, error, isFetching, refetch } = useQuery({
     queryKey: queryKeys.user.profile(),
     queryFn: userApi.getProfile,
-    staleTime: 1 * 1000, // 1초
-    gcTime: 60 * 1000, // 60초
+    staleTime: 60 * 5 * 1000, // 5분
+    gcTime: 60 * 10 * 1000, // 10분
     refetchOnWindowFocus: false,
     retry: 1,
   });
 
   return {
     nickname: data?.nickname || "",
-    email: data?.email,
     isLoading,
     isFetching,
     error: error?.message || null,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,47 +1,63 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
-interface UserProfile {
-  nickname: string;
-  email?: string;
-}
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
+import { userApi } from "@/lib/api/user";
 
 export function useUserProfile() {
-  const [nickname, setNickname] = useState<string>("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data,
+    isLoading,
+    error,
+    isFetching,
+    refetch,
+  } = useQuery({
+    queryKey: queryKeys.user.profile(),
+    queryFn: userApi.getProfile,
+    staleTime: 1 * 1000, // 1초 (max-age=1과 매칭)
+    gcTime: 60 * 1000, // 60초 (1 + 59 = 60초)
+    refetchOnWindowFocus: false, 
+    retry: 1,
+  });
 
-  useEffect(() => {
-    const fetchUserProfile = async () => {
-      try {
-        setIsLoading(true);
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/api/users/member/profile`,
-          {
-            method: "GET",
-            credentials: "include",
-          }
+  return {
+    nickname: data?.nickname || "",
+    email: data?.email,
+    isLoading,
+    isFetching, 
+    error: error?.message || null,
+    refetch,
+  };
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: userApi.updateProfile,
+    onMutate: async (newProfile) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.user.profile(),
+      });
+
+      const previousProfile = queryClient.getQueryData(queryKeys.user.profile());
+
+      queryClient.setQueryData(queryKeys.user.profile(), newProfile);
+
+      return { previousProfile };
+    },
+    onError: (err, newProfile, context) => {
+      if (context?.previousProfile) {
+        queryClient.setQueryData(
+          queryKeys.user.profile(),
+          context.previousProfile
         );
-
-        if (response.ok) {
-          const result = await response.json();
-          if (result.data?.nickname) {
-            setNickname(result.data.nickname);
-          }
-        } else {
-          setError("프로필 정보를 불러올 수 없습니다");
-        }
-      } catch (err) {
-        setError("네트워크 오류가 발생했습니다");
-        console.error("프로필 조회 실패:", err);
-      } finally {
-        setIsLoading(false);
       }
-    };
-
-    fetchUserProfile();
-  }, []);
-
-  return { nickname, isLoading, error };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.user.profile(),
+      });
+    },
+  });
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,22 +1,16 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 import { userApi } from "@/lib/api/user";
 
 export function useUserProfile() {
-  const {
-    data,
-    isLoading,
-    error,
-    isFetching,
-    refetch,
-  } = useQuery({
+  const { data, isLoading, error, isFetching, refetch } = useQuery({
     queryKey: queryKeys.user.profile(),
     queryFn: userApi.getProfile,
-    staleTime: 1 * 1000, // 1초 (max-age=1)
-    gcTime: 60 * 1000, // 60초 (max-age + stale-while~)
-    refetchOnWindowFocus: false, 
+    staleTime: 1 * 1000, // 1초
+    gcTime: 60 * 1000, // 60초
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 
@@ -24,40 +18,8 @@ export function useUserProfile() {
     nickname: data?.nickname || "",
     email: data?.email,
     isLoading,
-    isFetching, 
+    isFetching,
     error: error?.message || null,
     refetch,
   };
-}
-
-export function useUpdateProfile() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: userApi.updateProfile,
-    onMutate: async (newProfile) => {
-      await queryClient.cancelQueries({
-        queryKey: queryKeys.user.profile(),
-      });
-
-      const previousProfile = queryClient.getQueryData(queryKeys.user.profile());
-
-      queryClient.setQueryData(queryKeys.user.profile(), newProfile);
-
-      return { previousProfile };
-    },
-    onError: (err, newProfile, context) => {
-      if (context?.previousProfile) {
-        queryClient.setQueryData(
-          queryKeys.user.profile(),
-          context.previousProfile
-        );
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.user.profile(),
-      });
-    },
-  });
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -14,8 +14,8 @@ export function useUserProfile() {
   } = useQuery({
     queryKey: queryKeys.user.profile(),
     queryFn: userApi.getProfile,
-    staleTime: 1 * 1000, // 1초 (max-age=1과 매칭)
-    gcTime: 60 * 1000, // 60초 (1 + 59 = 60초)
+    staleTime: 1 * 1000, // 1초 (max-age=1)
+    gcTime: 60 * 1000, // 60초 (max-age + stale-while~)
     refetchOnWindowFocus: false, 
     retry: 1,
   });

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -34,25 +34,4 @@ export const userApi = {
 
     return result.data;
   },
-
-  updateProfile: async (data: { nickname: string }): Promise<UserProfile> => {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/users/member/profile`,
-      {
-        method: "PUT",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error("프로필 업데이트에 실패했습니다");
-    }
-
-    const result: ApiResponse<UserProfile> = await response.json();
-    return result.data;
-  },
 };

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,0 +1,58 @@
+interface UserProfile {
+  nickname: string;
+  email?: string;
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+export const userApi = {
+  getProfile: async (): Promise<UserProfile> => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/users/member/profile`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          "Cache-Control": "max-age=1, stale-while-revalidate=59",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("프로필 정보를 불러올 수 없습니다");
+    }
+
+    const result: ApiResponse<UserProfile> = await response.json();
+
+    if (!result.data?.nickname) {
+      throw new Error("닉네임 정보가 없습니다");
+    }
+
+    return result.data;
+  },
+
+  updateProfile: async (data: { nickname: string }): Promise<UserProfile> => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/users/member/profile`,
+      {
+        method: "PUT",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("프로필 업데이트에 실패했습니다");
+    }
+
+    const result: ApiResponse<UserProfile> = await response.json();
+    return result.data;
+  },
+};

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,6 +1,5 @@
 interface UserProfile {
   nickname: string;
-  email?: string;
 }
 
 interface ApiResponse<T> {

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,7 @@
+export const queryKeys = {
+  user: {
+    all: ["user"] as const,
+    profile: () => [...queryKeys.user.all, "profile"] as const,
+    settings: () => [...queryKeys.user.all, "settings"] as const,
+  },
+} as const;


### PR DESCRIPTION
## 🎫 What is the PR?
- Tanstack Query를 이용한 상태관리
- Tanstack Query 캐싱 전략
stale-while-revalidate 캐싱 전략을 사용

## 🎫 Changes
- lib/api/user.ts
- lib/queryKeys.ts
- hooks/useProfile.ts
- app/providers.tsx
- components/settings/SettingComtents.tsx

## 🎫 Thoughts
- Tanstack Query를 사용하여 상태관리 도입해봤습니다
- stale, gcTime에 따라 같은 API를 호출한다면 재호출을 하지 않도록 설정했습니다.
- 캐싱 전략중에 stale-while-revalidate 캐싱 전략을 도입했지만 현재 서버에서 HTTP캐싱을 사용하고 있어
아마 Network 탭에 들어가 Header를 확인해도 안보이실겁니다. 서버랑 얘기를 더 해보도록 하겠습니다.

## 🎫 Screenshot
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |


https://github.com/user-attachments/assets/0b8d9870-9c3a-4c12-bc69-8451e99d786f


## 🎫 To Reviewers
- 따로 없습니다!

## 🖥️ 주요 코드 설명
`user.ts`
- `max-age`
    
    캐싱된 응답이 최신 상태인지 오래된 것인지 여부를 결정합니다. 지정된 시간(초) **이내에 반복된 요청은 최신**, **이후의 요청은 오래된 것**으로 간주 = 유통기한
    
- `stale-while-revalidate`
    
    캐싱된 응답이 오래된 경우, 캐싱된 응답의 재검증 요청을 수행할지 서버에 요청을 보내 새 응답을 받을지 여부를 결정.  = 소비기한
    
    지정된 시간(초) 이내에 요청이 반복되면 오래된 캐싱 응답을 반환 - 재검증을 통해 캐싱된 응답을 최신으로 갱신
```Typescript
headers: {
          "Cache-Control": "max-age=1, stale-while-revalidate=59",
        },
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #46 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 프로필 데이터 로딩 방식 개선으로 더욱 안정적인 데이터 조회 기능 제공

* **성능 개선**
  * 데이터 캐싱 및 재요청 정책 최적화로 앱 응답성 향상
  * 백그라운드 데이터 동기화 비활성화를 통한 불필요한 요청 감소

* **스타일**
  * UI 레이아웃 미세 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->