### PR TITLE
[TRL-82] [Feat, Refactor] 상담 요약 조회 API 연동

### DIFF
--- a/src/app/(with-tab)/summary/(list)/page.tsx
+++ b/src/app/(with-tab)/summary/(list)/page.tsx
@@ -1,36 +1,10 @@
 import type { Metadata } from "next";
 import SummaryWrapper from "@/components/summary/list/SummaryWrapper";
-import { ChatCategory, SummaryCardData } from "@/types/summaryList";
 
 export const metadata: Metadata = {
   title: "상담 요약",
 };
 
-const mockData: SummaryCardData[] = [
-  {
-    id: 1,
-    title: "온라인 결제 시스템 도입",
-    date: "2025-05-30",
-    status: "pending",
-    content: "QR 코드 기반 결제 시스템 도입 희망...",
-    category: ChatCategory.ROAMING,
-  },
-  {
-    id: 2,
-    title: "온라인 결제 시스템 도입",
-    date: "2025-05-30",
-    status: "success",
-    content: "QR 코드 기반 결제 시스템 도입",
-    category: ChatCategory.PLAN,
-  },
-  {
-    id: 3,
-    date: "2025-08-30",
-    status: "error",
-    category: ChatCategory.ROAMING,
-  },
-];
-
 export default function SummaryPage() {
-  return <SummaryWrapper data={mockData} />;
+  return <SummaryWrapper />;
 }

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,23 +1,25 @@
-type BadgeStatus = "success" | "pending" | "error";
+import { SummaryStatus } from "@/types/summaryList";
 
-const BADGE_CONFIG: Record<BadgeStatus, { label: string; className: string }> =
-  {
-    success: {
-      label: "성공",
-      className: "w-[34px] bg-success-gradient",
-    },
-    pending: {
-      label: "요약 중",
-      className: "w-[44px] bg-pending-gradient",
-    },
-    error: {
-      label: "실패",
-      className: "w-[34px] bg-error-gradient",
-    },
-  };
+const BADGE_CONFIG: Record<
+  SummaryStatus,
+  { label: string; className: string }
+> = {
+  COMPLETED: {
+    label: "성공",
+    className: "w-[34px] bg-success-gradient",
+  },
+  PENDING: {
+    label: "요약 중",
+    className: "w-[44px] bg-pending-gradient",
+  },
+  FAILED: {
+    label: "실패",
+    className: "w-[34px] bg-error-gradient",
+  },
+};
 
 interface BadgeProps {
-  status: BadgeStatus;
+  status: SummaryStatus;
 }
 
 export default function Badge({ status }: BadgeProps) {

--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import HeaderHome from "@/components/common/HeaderHome";
-import ContentSection from "@/components/home/ContentSection";
 import HelperSection from "@/components/home/HelperSection";
 import SummaryStartCard from "@/components/home/SummaryStartCard";
 import SummaryList from "@/components/home/SummaryList";
@@ -12,10 +11,10 @@ export default function HomeContent() {
 
   return (
     <div className="flex flex-col items-center mb-8">
-      <HeaderHome 
-        title="SO:U+" 
+      <HeaderHome
+        title="SO:U+"
         description={isLoading ? "안녕하세요" : `안녕하세요, ${nickname}님`}
-        isHome 
+        isHome
         isScrollable={true}
       />
       <div className="w-[393px] mt-9">

--- a/src/components/home/Summary.tsx
+++ b/src/components/home/Summary.tsx
@@ -1,19 +1,25 @@
+import { SummaryStatus } from "@/types/summaryList";
+import { bgMap } from "@/utils/cardBgUtil";
 import { Calendar } from "lucide-react";
 
 interface SummaryContentProps {
-  content: string;
+  summaryPreview: string;
+  status: Exclude<SummaryStatus, "error">;
 }
 
-export default function Summary({ content }: SummaryContentProps) {
+export default function Summary({
+  summaryPreview,
+  status,
+}: SummaryContentProps) {
   return (
     <div
-      className="w-[311px] rounded-[10px] p-3 flex flex-col gap-y-2 bg-success-gradient"
+      className={`w-[311px] rounded-[10px] p-3 flex flex-col gap-y-2 ${bgMap[status]}`}
     >
       <div className="flex items-center gap-[3px]">
         <Calendar className="w-3 h-3 stroke-primary-500" />
         <p className="text-xs font-bold text-primary-500">AI 요약</p>
       </div>
-      <p className="text-sm text-white">{content}</p>
+      <p className="text-sm text-white">{summaryPreview}</p>
     </div>
   );
 }

--- a/src/components/home/Summary.tsx
+++ b/src/components/home/Summary.tsx
@@ -4,7 +4,7 @@ import { Calendar } from "lucide-react";
 
 interface SummaryContentProps {
   summaryPreview: string;
-  status: Exclude<SummaryStatus, "error">;
+  status: Exclude<SummaryStatus, "FAILED">;
 }
 
 export default function Summary({

--- a/src/components/home/SummaryList.tsx
+++ b/src/components/home/SummaryList.tsx
@@ -1,38 +1,29 @@
+"use client";
+
 import { SummaryHome } from "@/types/summaryList";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import Summary from "@/components/home/Summary";
 import EmptyState from "@/components/home/EmptySummary";
-
-const mockData: SummaryHome[] = [
-  {
-    id: 1,
-    title: "온라인 결제 시스템 도입",
-    date: "2025.07.30",
-    content: "QR 코드 기반 결제 시스템 도입 희망",
-  },
-  {
-    id: 2,
-    title: "온라인 결제 시스템 도입",
-    date: "2025.07.30",
-    content: "QR 코드 기반 결제 시스템 도입",
-  },
-];
+import { useSummaryList } from "@/hooks/useSummaryList";
+import ErrorContent from "@/components/summary/list/ErrorContent";
 
 interface SummaryListProps {
   nickname: string;
 }
 
 export default function SummaryList({ nickname }: SummaryListProps) {
+  const { data, isLoading, error } = useSummaryList();
+
   return (
     <div className="pt-8">
       <div className="flex justify-between items-center mb-[15px] px-[29px]">
         <h2 className="text-lg font-bold text-text-darkgray">
           {nickname || "김소유"}님의 요약내용
         </h2>
-        {mockData.length > 0 && (
-          <Link 
-            href="/summary" 
+        {!isLoading && data.length > 0 && (
+          <Link
+            href="/summary"
             className="text-xs text-text-lightgray hover:text-text-darkgray transition-colors"
           >
             더보기
@@ -40,14 +31,22 @@ export default function SummaryList({ nickname }: SummaryListProps) {
         )}
       </div>
 
-      {mockData.length > 0 ? (
+      {isLoading ? (
+        <p className="text-center text-sm text-text-lightgray py-6">
+          요약 내역을 불러오는 중입니다.
+        </p>
+      ) : error ? (
+        <p className="text-center text-sm text-text-lightgray py-6">
+          요약 내역을 불러오지 못했습니다.
+        </p>
+      ) : data.length > 0 ? (
         <div className="flex flex-col gap-[10px]">
-          {mockData.map((item) => (
-            <SummaryCard key={item.id} {...item} />
+          {data.slice(0, 2).map((item) => (
+            <SummaryCard key={item.counselId} {...item} />
           ))}
         </div>
       ) : (
-        <EmptyState 
+        <EmptyState
           text="요약된 상담이 없습니다"
           buttonText="요약 시작하기"
           buttonLink="/chat"
@@ -57,9 +56,15 @@ export default function SummaryList({ nickname }: SummaryListProps) {
   );
 }
 
-function SummaryCard({ id, title, date, content }: SummaryHome) {
+function SummaryCard({
+  counselId,
+  title,
+  date,
+  summaryPreview,
+  status,
+}: SummaryHome) {
   return (
-    <Link href={`/summary/${id}`}>
+    <Link href={`/summary/${counselId}`}>
       <div className="relative z-20 flex flex-col mx-auto w-[335px] min-h-[117px] rounded-[10px] shadow-card bg-white p-3 active:bg-gray-100 transition-all duration-200">
         <div className="flex justify-between items-center mb-3">
           <div className="flex items-center gap-2">
@@ -68,8 +73,11 @@ function SummaryCard({ id, title, date, content }: SummaryHome) {
           </div>
           <ChevronRight className="w-6 h-4 stroke-text-lightgray" />
         </div>
-
-        <Summary content={content ?? ""} />
+        {status === "FAILED" ? (
+          <ErrorContent variant="home" />
+        ) : (
+          <Summary summaryPreview={summaryPreview ?? ""} status={status} />
+        )}
       </div>
     </Link>
   );

--- a/src/components/summary/list/ErrorContent.tsx
+++ b/src/components/summary/list/ErrorContent.tsx
@@ -1,8 +1,18 @@
 import { CircleAlert, RotateCcw } from "lucide-react";
 
-export default function ErrorContent() {
+interface ErrorContentProps {
+  variant?: "home" | "summary";
+}
+
+export default function ErrorContent({
+  variant = "summary",
+}: ErrorContentProps) {
+  const heightClass = variant === "home" ? "h-[68px]" : "h-[73px]";
+
   return (
-    <div className="w-[311px] h-[73px] bg-[#FFECEC] rounded-[10px] p-3 border-[0.5px] border-[#FFB4B4] flex items-center">
+    <div
+      className={`w-[311px] ${heightClass} bg-[#FFECEC] rounded-[10px] p-3 border-[0.5px] border-[#FFB4B4] flex items-center`}
+    >
       <div className="w-8 h-8 bg-error-500 rounded-[10px] flex items-center justify-center">
         <CircleAlert className="w-[15px] h-[15px] stroke-white" />
       </div>

--- a/src/components/summary/list/SummaryCard.tsx
+++ b/src/components/summary/list/SummaryCard.tsx
@@ -6,14 +6,14 @@ import ErrorContent from "@/components/summary/list/ErrorContent";
 import SummaryContent from "@/components/summary/list/SummaryContent";
 
 export default function SummaryCard({
-  id,
+  counselId,
   title,
   date,
   status,
-  content,
+  summaryPreview,
 }: SummaryCardData) {
   return (
-    <Link href={`/summary/${id}`}>
+    <Link href={`/summary/${counselId}`}>
       <div className="relative z-20 flex flex-col mx-auto w-[335px] min-h-[141px] rounded-[10px] shadow-card bg-white p-3 active:bg-gray-100 transition-all duration-200">
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-2">
@@ -21,7 +21,7 @@ export default function SummaryCard({
             <Badge status={status} />
           </div>
 
-          {status !== "error" && (
+          {status !== "FAILED" && (
             <ChevronRight className="w-6 h-4 stroke-text-lightgray" />
           )}
         </div>
@@ -31,10 +31,13 @@ export default function SummaryCard({
           <p className="text-[8px] text-text-lightgray">{date}</p>
         </div>
 
-        {status === "error" ? (
+        {status === "FAILED" ? (
           <ErrorContent />
         ) : (
-          <SummaryContent status={status} content={content ?? ""} />
+          <SummaryContent
+            status={status}
+            summaryPreview={summaryPreview ?? ""}
+          />
         )}
       </div>
     </Link>

--- a/src/components/summary/list/SummaryContent.tsx
+++ b/src/components/summary/list/SummaryContent.tsx
@@ -1,29 +1,25 @@
 import { SummaryStatus } from "@/types/summaryList";
+import { bgMap } from "@/utils/cardBgUtil";
 import { Calendar } from "lucide-react";
 
 interface SummaryContentProps {
   status: Exclude<SummaryStatus, "error">;
-  content: string;
+  summaryPreview: string;
 }
-
-const bgMap = {
-  pending: "bg-pending-gradient",
-  success: "bg-success-gradient",
-};
 
 export default function SummaryContent({
   status,
-  content,
+  summaryPreview,
 }: SummaryContentProps) {
   return (
     <div
-      className={`w-[311px] rounded-[10px] p-3 flex flex-col gap-y-1.5 ${bgMap[status]}`}
+      className={`w-[311px] min-h-[73px] rounded-[10px] p-3 flex flex-col gap-y-1.5 ${bgMap[status]}`}
     >
       <div className="flex items-center gap-[3px]">
         <Calendar className="w-3 h-3 stroke-primary-500" />
         <p className="text-xs font-bold text-primary-500">AI 요약</p>
       </div>
-      <p className="text-sm text-white">{content}</p>
+      <p className="text-sm text-white">{summaryPreview}</p>
     </div>
   );
 }

--- a/src/components/summary/list/SummaryContent.tsx
+++ b/src/components/summary/list/SummaryContent.tsx
@@ -3,7 +3,7 @@ import { bgMap } from "@/utils/cardBgUtil";
 import { Calendar } from "lucide-react";
 
 interface SummaryContentProps {
-  status: Exclude<SummaryStatus, "error">;
+  status: Exclude<SummaryStatus, "FAILED">;
   summaryPreview: string;
 }
 

--- a/src/components/summary/list/SummaryWrapper.tsx
+++ b/src/components/summary/list/SummaryWrapper.tsx
@@ -5,24 +5,25 @@ import CategorySection from "@/components/summary/list/CategorySection";
 import YearSelector from "@/components/summary/list/YearSelector";
 import MonthSection from "@/components/summary/list/MonthSection";
 import SummaryCard from "@/components/summary/list/SummaryCard";
-import { ChatCategory, SummaryCardData } from "@/types/summaryList";
+import { ChatCategory } from "@/types/summaryList";
+import { useSummaryList } from "@/hooks/useSummaryList";
 
-interface SummaryWrapperProps {
-  data: SummaryCardData[];
-}
+export default function SummaryWrapper() {
+  const { data, isLoading, error } = useSummaryList();
 
-export default function SummaryWrapper({ data }: SummaryWrapperProps) {
   const [category, setCategory] = useState<ChatCategory>(ChatCategory.ALL);
 
   // 데이터 연도
-  const getYear = (date?: string) => (date ? Number(date.split("-")[0]) : null);
+  const getYear = (date?: string) => (date ? Number(date.split(".")[0]) : null);
+  // FIXME: . -> - 로 데이터구조 바꾼 뒤 수정하기
 
   const initialYear = getYear(data[0]?.date) ?? new Date().getFullYear();
   const [year, setYear] = useState<number>(initialYear);
 
   // 데이터 월
   const getMonth = (date?: string) =>
-    date ? Number(date.split("-")[1]) : null;
+    date ? Number(date.split(".")[1]) : null;
+  // FIXME: . -> - 로 데이터구조 바꾼 뒤 수정하기
 
   let prevMonth: number | null = null;
 
@@ -35,6 +36,22 @@ export default function SummaryWrapper({ data }: SummaryWrapperProps) {
   const yearFilteredData = filteredData.filter(
     (item) => getYear(item.date) === year
   );
+
+  if (isLoading) {
+    return (
+      <p className="text-center text-sm text-text-lightgray py-6">
+        상담 내역을 불러오는 중입니다.
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-center text-sm text-red-500 py-6">
+        상담 내역을 불러오지 못했습니다.
+      </p>
+    );
+  }
 
   return (
     <div className="mb-8 w-[335px]">
@@ -56,7 +73,7 @@ export default function SummaryWrapper({ data }: SummaryWrapperProps) {
             if (showMonth) prevMonth = month;
 
             return (
-              <div key={item.id}>
+              <div key={item.counselId}>
                 {showMonth && month && <MonthSection month={month} />}
                 <SummaryCard {...item} />
               </div>

--- a/src/hooks/useSummaryList.ts
+++ b/src/hooks/useSummaryList.ts
@@ -1,0 +1,23 @@
+import { summaryListApi } from "@/lib/api/summaryList";
+import { queryKeys } from "@/lib/queryKeys";
+import { SummaryCardData } from "@/types/summaryList";
+import { useQuery } from "@tanstack/react-query";
+
+export function useSummaryList() {
+  const query = useQuery<SummaryCardData[]>({
+    queryKey: queryKeys.summary.list(),
+    queryFn: summaryListApi.getSummaryList,
+    staleTime: 60 * 1000, // 1분
+    gcTime: 5 * 60 * 1000, // 5분
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {
+    data: query.data ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error instanceof Error ? query.error.message : null,
+    refetch: query.refetch,
+  };
+}

--- a/src/lib/api/summaryList.ts
+++ b/src/lib/api/summaryList.ts
@@ -1,0 +1,28 @@
+import { ApiResponse } from "@/types/api";
+import { SummaryCardData } from "@/types/summaryList";
+
+export const summaryListApi = {
+  getSummaryList: async (): Promise<SummaryCardData[]> => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/counsels`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          "Cache-Control": "max-age=1, stale-while-revalidate=59",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("상담 요약 목록을 불러올 수 없습니다");
+    }
+
+    const result: ApiResponse<SummaryCardData> = await response.json();
+
+    if (!Array.isArray(result.data)) {
+      throw new Error("요약 데이터 형식이 올바르지 않습니다");
+    }
+    return result.data;
+  },
+};

--- a/src/lib/api/summaryList.ts
+++ b/src/lib/api/summaryList.ts
@@ -18,7 +18,7 @@ export const summaryListApi = {
       throw new Error("상담 요약 목록을 불러올 수 없습니다");
     }
 
-    const result: ApiResponse<SummaryCardData> = await response.json();
+    const result: ApiResponse<SummaryCardData[]> = await response.json();
 
     if (!Array.isArray(result.data)) {
       throw new Error("요약 데이터 형식이 올바르지 않습니다");

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,11 +1,7 @@
+import { ApiResponse } from "@/types/api";
+
 interface UserProfile {
   nickname: string;
-}
-
-interface ApiResponse<T> {
-  success: boolean;
-  message: string;
-  data: T;
 }
 
 export const userApi = {

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -4,4 +4,8 @@ export const queryKeys = {
     profile: () => [...queryKeys.user.all, "profile"] as const,
     settings: () => [...queryKeys.user.all, "settings"] as const,
   },
+  summary: {
+    all: ["summary"] as const,
+    list: () => [...queryKeys.summary.all, "list"] as const,
+  },
 } as const;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,5 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}

--- a/src/types/summaryList.ts
+++ b/src/types/summaryList.ts
@@ -1,6 +1,6 @@
 // 요약 list 관련 type
 
-export type SummaryStatus = "pending" | "success" | "error";
+export type SummaryStatus = "PENDING" | "COMPLETED" | "FAILED";
 
 export enum ChatCategory {
   ALL = "ALL",
@@ -11,14 +11,14 @@ export enum ChatCategory {
 // 연도에 따른 월
 export type Month = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export interface SummaryHome { 
-  id: number;
+export interface SummaryHome {
+  counselId: number;
   title?: string;
   date: string;
-  content?: string;
+  summaryPreview?: string;
+  status: SummaryStatus;
 }
 
-export interface SummaryCardData extends SummaryHome { 
-  status: SummaryStatus;
+export interface SummaryCardData extends SummaryHome {
   category: ChatCategory;
 }

--- a/src/utils/cardBgUtil.ts
+++ b/src/utils/cardBgUtil.ts
@@ -1,0 +1,5 @@
+export const bgMap = {
+  PENDING: "bg-pending-gradient",
+  COMPLETED: "bg-success-gradient",
+  FAILED: "bg-error-gradient",
+};


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 상담 요약 조회 API를 연동하였습니다.
- api 응답 필드 구조에 맞춰서 프론트쪽 필드를 통일하였습니다 ( content -> `summaryPreview`, status 종류 (`PENDING`, success -> `COMPLETED`, error -> `FAILED`) 등 )

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- `app/(with-tab)/summary/(list)/page.tsx`
- `components/common/Badge.tsx`
- `components/home/HomeContent.tsx`
- `components/home/Summary.tsx`
- `components/home/SummaryList.tsx`
- `components/summary/list/ErrorContent.tsx`
- `components/summary/list/SummaryCard.tsx`
- `components/summary/list/SummaryContent.tsx`
- `components/summary/list/SummaryWrapper.tsx`
- `hooks/useSummaryList.ts`
- `lib/api/summaryList.ts`
- `lib/api/user.ts`
- `lib/queryKeys.ts`
- `types/api.ts`
- `types/summaryList.ts`
- `utils/cardBgUtil.ts`


## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
- 초기에는 서버 컴포넌트 구조를 유지하기 위해 page.tsx에서 조회 API를 호출해서 데이터를 내려주려고 했지만, 상담 리스트 특성상 잦은 갱신과 상태 관리가 필요하다고 판단하여 이에 TanStack Query를 도입하면서 데이터 조회를 클라이언트 컴포넌트에서 담당하도록 구현하였습니다.

- 현재 보니까 `/components/home/Summary.tsx` 와 `/components/summary/list/SummaryContent.tsx`와 거의 유사해서 추후 하나로 합쳐도 될 것 같습니다.

- 추후 프론트엔드 고도화 작업할 때, isLoading에서 렌더링되는 화면은 스켈레톤ui 적용하면 더욱 이쁠 것 같습니다.
 

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->
|    구현 내용    |   Home   |  Summary  | 
| :-------------: | :----------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/bcf8da58-5f1b-4d72-9729-49a5e93f54ec" width ="250"> | <img src = "https://github.com/user-attachments/assets/738bb8df-0269-43da-b473-53cb0b7bdcce" width ="250"> | 

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 현재 date 의 데이터 형식이 '.'로 되어있어서 임시로 '-' 에서 '.' 으로 수정하였습니다.
- 백엔드에서 category 필드가 추가되면 그때 카테고리 데이터를 넣어 필터링 잘 되는 지 확인하겠습니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`useSummaryList`
- summary list 관련 tanstack query를 사용한 hook
```swift
import { summaryListApi } from "@/lib/api/summaryList";
import { queryKeys } from "@/lib/queryKeys";
import { SummaryCardData } from "@/types/summaryList";
import { useQuery } from "@tanstack/react-query";

export function useSummaryList() {
  const query = useQuery<SummaryCardData[]>({
    queryKey: queryKeys.summary.list(),
    queryFn: summaryListApi.getSummaryList,
    staleTime: 60 * 1000, // 1분
    gcTime: 5 * 60 * 1000, // 5분
    refetchOnWindowFocus: false,
    retry: 1,
  });

  return {
    data: query.data ?? [],
    isLoading: query.isLoading,
    isFetching: query.isFetching,
    error: query.error instanceof Error ? query.error.message : null,
    refetch: query.refetch,
  };
}

```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #50 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 요약 목록이 실시간 API로 동적으로 로드되며 로딩/오류 상태가 화면에 표시됩니다.
  * 홈 목록에 최대 항목 노출 및 "더보기" 링크 표시가 데이터에 따라 조건부로 동작합니다.

* **Bug Fixes**
  * 요약 카드의 실패 항목은 전용 오류 영역으로 대체되어 혼동을 줄였습니다.
  * 상태 라벨과 카드 배경 스타일이 일관되게 업데이트되어 가독성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->